### PR TITLE
Add Xquik API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _[Here](https://github.com/sindresorhus/awesome/blob/master/contributing.md) are
  * [Meteor](http://docs.meteor.com/#/basic/) Custom, easy to edit (the team is pretty responsive about editing their docs), and on the whole, quite comprehensive.
  * [Stripe](https://stripe.com/docs/api) This is how docs should look. Absolutely well done.
  * [Twilio](https://www.twilio.com/docs/) The Twilio docs are extremely full featured, with interactive examples, and code samples in various languages. - @tcg
+ * [Xquik](https://docs.xquik.com) REST API documentation for the Xquik X/Twitter automation platform. Covers 40+ API endpoints, MCP server setup, webhook integration, OpenAPI spec, and interactive examples.
  
 ### Documentation Resources
 


### PR DESCRIPTION
## Summary
- Add [Xquik API Documentation](https://docs.xquik.com) to the Awesome Docs section
- REST API docs for the Xquik X/Twitter automation platform covering 40+ endpoints, MCP server setup, webhook integration, OpenAPI spec, and interactive examples
- Built with [Mintlify](https://mintlify.com), source at [Xquik-dev/xquik-docs](https://github.com/Xquik-dev/xquik-docs)